### PR TITLE
Fix GoToWiki

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vs-code-wiki",
   "displayName": "VS Code Wiki",
   "description": "Wiki for VS Code",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/hannut91/vs-code-wiki.git"

--- a/src/utils/word.test.ts
+++ b/src/utils/word.test.ts
@@ -1,4 +1,6 @@
-import { extractLinkName, containsInLink, deleteExtname } from './word';
+import {
+  extractLinkName, containsInLink, deleteExtname, findLinkedTexts
+} from './word';
 
 test('extract word', () => {
   expect(extractLinkName('[Docker](Docker)')).toBe('Docker');
@@ -21,4 +23,14 @@ test('deleteExtname', () => {
       'Install [Docker](Docker.md) with [Homebrew](Homebrew.md) test.md'
     )
   ).toBe('Install [Docker](Docker) with [Homebrew](Homebrew) test.md');
+});
+
+test('findLinkedTexts', () => {
+  expect(findLinkedTexts('[TestLink](TestLink.md)')).toEqual(
+    [{start: 0, end: 23, text: '[TestLink](TestLink.md)'}]
+  );
+
+  expect(findLinkedTexts('[Test2Link](Test2Link.md)')).toEqual(
+    [{start: 0, end: 25, text: '[Test2Link](Test2Link.md)'}]
+  );
 });

--- a/src/utils/word.ts
+++ b/src/utils/word.ts
@@ -1,5 +1,5 @@
 export const linkedTextsRegExp =
-  new RegExp(/\[[a-zA-Z\s-]+\]\([[a-zA-Z\s.-]+\)/g);
+  new RegExp(/\[[a-zA-Z0-9\s-]+\]\([[a-zA-Z0-9\s.-]+\)/g);
 const linkRegExp = new RegExp(/\(.+\)/);
 
 export const extractLinkName = (text: string): string => {


### PR DESCRIPTION
Fix to work even if the letters are mixed with numbers.
Add number regex to linkedTextsRegExp.

Issue: https://github.com/hannut91/vs-code-wiki/issues/19