### PR TITLE
Fix invalid backup file name in Windows

### DIFF
--- a/src/services/backup.service.ts
+++ b/src/services/backup.service.ts
@@ -14,7 +14,7 @@ export const backup = async (
   }
 
   const originFile = join(basepath, filename);
-  const date = moment().format('YYYY-MM-DD_HH:mm:ss_');
+  const date = moment().format('YYYY-MM-DD_HH-mm-ss_');
   const backupFile = join(backupDir, date + filename);
   await promises.copyFile(originFile, backupFile);
 


### PR DESCRIPTION
Windows doesn't accept colons in the path https://gist.github.com/doctaphred/d01d05291546186941e1b7ddc02034d3

This changes the format of the backup string so it is valid.