### PR TITLE
Add new configuration flag to open basePath as workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "wiki.baseRootOpenAsFolder": {
           "type": "boolean",
           "default": "",
-          "description": "Open the whole folder containing the base file."
+          "description": "Open the entire folder containing the base file as a workspace."
         },
         "wiki.targetRootFile": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
           "default": "",
           "description": "The file where the navigation into the wiki starts (basically the wiki entry file)."
         },
-        "wiki.baseRootOpenAsFolder": {
+        "wiki.openBasePathAsWorkspace": {
           "type": "boolean",
-          "default": "",
+          "default": false,
           "description": "Open the entire folder containing the base file as a workspace."
         },
         "wiki.targetRootFile": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
           "default": "",
           "description": "The file where the navigation into the wiki starts (basically the wiki entry file)."
         },
+        "wiki.baseRootOpenAsFolder": {
+          "type": "boolean",
+          "default": "",
+          "description": "Open the whole folder containing the base file."
+        },
         "wiki.targetRootFile": {
           "type": "string",
           "default": "",

--- a/src/commands/open-wiki.ts
+++ b/src/commands/open-wiki.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import { createWikiDirectory, createFile } from '../utils/file';
-import { getRootFile, getBasePath } from '../config';
+import { getRootFile, getBasePath, getOpenRootFileFolder } from '../config';
 
 export const openWiki = async () => {
   const basePath = getBasePath();
@@ -18,6 +18,12 @@ export const openWiki = async () => {
   } catch (err) {
     vscode.window.showInformationMessage(err);
     return;
+  }
+
+  const openRootFileFolder = getOpenRootFileFolder();
+  const openRootFileFolderUri = vscode.Uri.file(basePath);
+  if (openRootFileFolder) {
+    await vscode.commands.executeCommand('vscode.openFolder', openRootFileFolderUri);
   }
 
   const document = await vscode.workspace.openTextDocument(rootFile);

--- a/src/commands/open-wiki.ts
+++ b/src/commands/open-wiki.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import { createWikiDirectory, createFile } from '../utils/file';
-import { getRootFile, getBasePath, getOpenRootFileFolder } from '../config';
+import { getRootFile, getBasePath, getOpenBasePathAsWorkspace } from '../config';
 
 export const openWiki = async () => {
   const basePath = getBasePath();
@@ -20,10 +20,10 @@ export const openWiki = async () => {
     return;
   }
 
-  const openRootFileFolder = getOpenRootFileFolder();
-  const openRootFileFolderUri = vscode.Uri.file(basePath);
-  if (openRootFileFolder) {
-    await vscode.commands.executeCommand('vscode.openFolder', openRootFileFolderUri);
+  const openBasePathAsWorkspace = getOpenBasePathAsWorkspace();
+  const basePathUri = vscode.Uri.file(basePath);
+  if (openBasePathAsWorkspace) {
+    await vscode.commands.executeCommand('vscode.openFolder', basePathUri, false);
   }
 
   const document = await vscode.workspace.openTextDocument(rootFile);

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,8 @@ export const indexFile = () => configuration().get<string>('baseRootFile') || 'i
 export const getBasePath = () => configuration().get<string>('basePath')
   || join(homedir(), 'vscode_wiki');
 
+export const getOpenRootFileFolder = () => configuration().get<boolean>('baseRootOpenAsFolder') || false;
+
 export const getRootFile = () => join(getBasePath(), indexFile());
 
 export const getTargetRootFile = () => configuration().get<string>('targetRootFile');

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,12 +4,12 @@ import { join } from 'path';
 
 const configuration = () => workspace.getConfiguration('wiki');
 
-export const indexFile = () => configuration().get<string>('baseRootFile') || 'index.md';
+export const indexFile = () => configuration().get<string>('baseRootFile', 'index.md');
 
 export const getBasePath = () => configuration().get<string>('basePath')
   || join(homedir(), 'vscode_wiki');
 
-export const getOpenRootFileFolder = () => configuration().get<boolean>('baseRootOpenAsFolder') || false;
+export const getOpenBasePathAsWorkspace = () => configuration().get<boolean>('openBasePathAsWorkspace', false);
 
 export const getRootFile = () => join(getBasePath(), indexFile());
 


### PR DESCRIPTION
Hello

I have another pull request to offer, where the 'Open Wiki' command also opens the configured `basePath` as a workspace in Visual Studio Code.
I use this very often myself, for example, as I have several VSCode snippets configured in my wiki folder.

Greetings