### PR TITLE
Default base root file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vs-code-wiki",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vs-code-wiki",
   "displayName": "VS Code Wiki",
   "description": "Wiki for VS Code",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/hannut91/vs-code-wiki.git"

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 
 const configuration = () => workspace.getConfiguration('wiki');
 
-export const indexFile = () => configuration().get<string>('baseRootFile', 'index.md');
+export const indexFile = () => configuration().get<string>('baseRootFile') || 'index.md';
 
 export const getBasePath = () => configuration().get<string>('basePath')
   || join(homedir(), 'vscode_wiki');


### PR DESCRIPTION
Default baseRootFile is empty string. So default value is always has empty string.
If baseRootFile is empty, returns index.md.